### PR TITLE
Improve error handling for PHP setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 data/*.db
+data/sessions/

--- a/api/config.php
+++ b/api/config.php
@@ -22,6 +22,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'OPTIONS') {
 // Create or open SQLite database
 function getDB() {
     try {
+        // Ensure the SQLite PDO driver is available
+        if (!in_array('sqlite', PDO::getAvailableDrivers())) {
+            http_response_code(500);
+            throw new PDOException('SQLite driver not installed');
+        }
+
         $db = new PDO('sqlite:' . DB_PATH);
         $db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
         

--- a/api/db-init.php
+++ b/api/db-init.php
@@ -2,13 +2,21 @@
 // Initialize database - run this once to set up the database
 require_once 'config.php';
 
-$db = getDB();
-echo "Database initialized successfully at: " . DB_PATH . "\n";
-echo "Table 'todos' created.\n";
+try {
+    $db = getDB();
 
-// Test the database
-$testId = uniqid('test_', true);
-$db->exec("INSERT INTO todos (id, text, user_id) VALUES ('$testId', 'Test Todo', 'test_user')");
-$db->exec("DELETE FROM todos WHERE id = '$testId'");
-echo "Database test successful.\n";
+    // Test the database connection and permissions
+    $testId = uniqid('test_', true);
+    $db->exec("INSERT INTO todos (id, text, user_id) VALUES ('$testId', 'Test Todo', 'test_user')");
+    $db->exec("DELETE FROM todos WHERE id = '$testId'");
+
+    echo json_encode([
+        'success' => true,
+        'message' => 'Database initialized successfully',
+        'path' => DB_PATH
+    ]);
+} catch (Exception $e) {
+    http_response_code(500);
+    echo json_encode(['success' => false, 'error' => $e->getMessage()]);
+}
 ?>

--- a/index.php
+++ b/index.php
@@ -1,4 +1,10 @@
 <?php
+// Use a writable session path inside the project to avoid 500 errors
+$sessionDir = __DIR__ . '/data/sessions';
+if (!is_dir($sessionDir)) {
+    mkdir($sessionDir, 0755, true);
+}
+session_save_path($sessionDir);
 session_start();
 if (!isset($_SESSION['user_id'])) {
     $_SESSION['user_id'] = uniqid('user_', true);


### PR DESCRIPTION
## Summary
- Ensure session directory exists to prevent 500 errors
- Check for SQLite driver and provide clearer errors
- Return JSON output from database initialization and ignore session files

## Testing
- `php -l index.php`
- `php -l api/config.php`
- `php -l api/db-init.php`


------
https://chatgpt.com/codex/tasks/task_e_68a8084025648323a9246ab9e4c1db16