### PR TITLE
Improve dark mode toggle and JS initialization

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -1,8 +1,12 @@
+// Only initialize todo-related variables if we're on the todo page
 let todos = [];
-const userIdElement = document.getElementById('userId');
-const userId = userIdElement ? userIdElement.value : null;
+let userId = null;
 
-if (userId) {
+// Check if we're on the todo page (userId element exists)
+const userIdElement = document.getElementById('userId');
+if (userIdElement) {
+    userId = userIdElement.value;
+
     // Load todos on page load
     document.addEventListener('DOMContentLoaded', () => {
         loadTodos();

--- a/assets/style.css
+++ b/assets/style.css
@@ -41,46 +41,85 @@
     --empty-state-color: #64748b;
 }
 
-/* Dark mode toggle button */
+/* Dark mode toggle button - improved design */
 .theme-toggle {
     position: fixed;
     top: 20px;
     right: 20px;
     z-index: 1000;
-    background: var(--card-bg);
-    border: 1px solid var(--card-border);
-    border-radius: 50%;
-    width: 50px;
-    height: 50px;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    border: 2px solid rgba(255, 255, 255, 0.3);
+    border-radius: 50px;
+    width: 60px;
+    height: 32px;
+    padding: 3px;
+    cursor: pointer;
+    transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    box-shadow: 0 4px 12px 0 rgba(102, 126, 234, 0.3);
     display: flex;
     align-items: center;
-    justify-content: center;
-    cursor: pointer;
-    transition: all 0.3s ease;
-    box-shadow: 0 4px 12px 0 var(--card-shadow);
 }
 
 .theme-toggle:hover {
-    transform: scale(1.1);
+    transform: translateY(-2px);
+    box-shadow: 0 6px 20px 0 rgba(102, 126, 234, 0.4);
+}
+
+.theme-toggle::before {
+    content: '';
+    position: absolute;
+    width: 24px;
+    height: 24px;
+    background: white;
+    border-radius: 50%;
+    transition: transform 0.3s cubic-bezier(0.4, 0, 0.2, 1);
+    transform: translateX(0);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+[data-theme="dark"] .theme-toggle::before {
+    transform: translateX(26px);
 }
 
 .theme-toggle svg {
-    width: 24px;
-    height: 24px;
-    color: var(--text-primary);
+    position: absolute;
+    width: 16px;
+    height: 16px;
     transition: all 0.3s ease;
 }
 
 .theme-toggle .sun-icon {
-    display: none;
+    right: 8px;
+    color: rgba(255, 255, 255, 0.7);
 }
 
-[data-theme="dark"] .theme-toggle .sun-icon {
-    display: block;
+.theme-toggle .moon-icon {
+    left: 8px;
+    color: rgba(255, 255, 255, 0.7);
 }
 
-[data-theme="dark"] .theme-toggle .moon-icon {
-    display: none;
+[data-theme="dark"] .theme-toggle {
+    background: linear-gradient(135deg, #1e293b 0%, #334155 100%);
+    border-color: rgba(148, 163, 184, 0.3);
+}
+
+/* Mobile adjustments for toggle */
+@media (max-width: 640px) {
+    .theme-toggle {
+        top: 15px;
+        right: 15px;
+        width: 54px;
+        height: 28px;
+    }
+
+    .theme-toggle::before {
+        width: 22px;
+        height: 22px;
+    }
+
+    [data-theme="dark"] .theme-toggle::before {
+        transform: translateX(24px);
+    }
 }
 
 /* Update existing styles to use CSS variables */

--- a/index.php
+++ b/index.php
@@ -158,13 +158,13 @@ if (isset($_GET['logout'])) {
     <?php endif; ?>
 </head>
 <body onload="initTheme()">
-    <!-- Add theme toggle button -->
+    <!-- Dark mode toggle with improved design -->
     <button class="theme-toggle" onclick="toggleTheme()" aria-label="Toggle dark mode">
-        <svg class="sun-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 3v1m0 16v1m9-9h-1M4 12H3m15.364 6.364l-.707-.707M6.343 6.343l-.707-.707m12.728 0l-.707.707M6.343 17.657l-.707.707M16 12a4 4 0 11-8 0 4 4 0 018 0z"></path>
+        <svg class="moon-icon" fill="currentColor" viewBox="0 0 20 20">
+            <path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path>
         </svg>
-        <svg class="moon-icon" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M20.354 15.354A9 9 0 018.646 3.646 9.003 9.003 0 0012 21a9.003 9.003 0 008.354-5.646z"></path>
+        <svg class="sun-icon" fill="currentColor" viewBox="0 0 20 20">
+            <path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clip-rule="evenodd"></path>
         </svg>
     </button>
     <div class="container">
@@ -174,18 +174,20 @@ if (isset($_GET['logout'])) {
                 <p class="login-subtitle">PIN eingeben für Zugang</p>
                 
                 <form method="POST">
+                    <!-- Hidden username field for accessibility -->
+                    <input type="hidden" name="username" value="family_user" autocomplete="username">
                     <?php if (isset($error)): ?>
                         <p class="error-message"><?php echo $error; ?></p>
                     <?php endif; ?>
-                    <input 
-                        type="password" 
-                        name="pin" 
-                        class="pin-input" 
-                        placeholder="••••" 
+                    <input
+                        type="password"
+                        name="pin"
+                        class="pin-input"
+                        placeholder="••••"
                         maxlength="4"
                         pattern="[0-9]{4}"
                         inputmode="numeric"
-                        autocomplete="new-password"
+                        autocomplete="current-password"
                         required
                         autofocus
                     >


### PR DESCRIPTION
## Summary
- guard todo initialization by checking for page elements
- restyle dark mode toggle with gradient slider and mobile tweaks
- add hidden username field and adjust login autocomplete for accessibility

## Testing
- `php -l index.php`
- `node --check assets/app.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a82e0d5818832387771fa5f8580eca